### PR TITLE
[FIX] 기존의 피드 댓글 등록시 리턴 방식 변경 : 피드 댓글 번호 리턴 Dto에 추가

### DIFF
--- a/src/main/java/com/example/trip/controller/FeedCommentController.java
+++ b/src/main/java/com/example/trip/controller/FeedCommentController.java
@@ -18,11 +18,12 @@ public class FeedCommentController {
     private final FeedCommentService feedCommentService;
 
     @PostMapping("/feed/comment/{feedDetailLocId}")
-    public ResponseEntity<FeedResponseDto.FeedResponseDefault> registerFeedComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long feedDetailLocId, @RequestBody FeedRequestDto.FeedRequestCommentRegisterDto feedRequestCommentRegisterDto) {
-        feedCommentService.registerFeedComment(userDetails.getUser(), feedDetailLocId, feedRequestCommentRegisterDto);
-        return new ResponseEntity<>(FeedResponseDto.FeedResponseDefault.builder()
+    public ResponseEntity<FeedResponseDto.FeedResponseOptional> registerFeedComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long feedDetailLocId, @RequestBody FeedRequestDto.FeedRequestCommentRegisterDto feedRequestCommentRegisterDto) {
+        Long commentId = feedCommentService.registerFeedComment(userDetails.getUser(), feedDetailLocId, feedRequestCommentRegisterDto);
+        return new ResponseEntity<>(FeedResponseDto.FeedResponseOptional.builder()
                 .result("success")
                 .msg("댓글 등록 성공하였습니다.")
+                .data(commentId)
                 .build(), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/trip/service/FeedCommentService.java
+++ b/src/main/java/com/example/trip/service/FeedCommentService.java
@@ -20,7 +20,7 @@ public class FeedCommentService {
     private final CommentRepository commentRepository;
     private final FeedDetailLocRepository feedDetailLocRepository;
 
-    public void registerFeedComment(User user, Long feedDetailLocId, FeedRequestDto.FeedRequestCommentRegisterDto feedRequestCommentRegisterDto) {
+    public Long registerFeedComment(User user, Long feedDetailLocId, FeedRequestDto.FeedRequestCommentRegisterDto feedRequestCommentRegisterDto) {
         // 해당 피드 상세 위치 값이 있는지 체크
         FeedDetailLoc feedDetailLoc = feedDetailLocRepository.findById(feedDetailLocId)
                 .orElseThrow(() -> new FeedDetailLocNotFoundException());
@@ -29,8 +29,8 @@ public class FeedCommentService {
                 .user(user)
                 .content(feedRequestCommentRegisterDto.getContent())
                 .build();
-        commentRepository.save(feedComment);
-
+        FeedComment comment = commentRepository.save(feedComment);
+        return comment.getId();
     }
 
     @Transactional


### PR DESCRIPTION
### ✉️ 제목
[FIX] 기존의 피드 댓글 등록시 리턴 방식 변경 : 피드 댓글 번호 리턴 Dto에 추가
### ☁️ 내용

### ❗️ 특이사항

---

closes #
