### PR TITLE
[FIX] 토큰 재발급 API 추가 및 시큐리티 로직 변경(Filter추가) + [TEST] 도메인, 서비스 단위 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/trip/advice/ExceptionController.java
+++ b/src/main/java/com/example/trip/advice/ExceptionController.java
@@ -129,5 +129,14 @@ public class ExceptionController {
         return new ResponseEntity<>(new Fail("중복된 유저명입니다."), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(TitleNotFoundException.class)
+    public ResponseEntity<Fail> TitleNotFoundException(TitleNotFoundException e) {
+        return new ResponseEntity<>(new Fail("제목이 빈 값입니다."), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RefreshTokenNotFoundException.class)
+    public ResponseEntity<Fail> RefreshTokenNotFoundException(RefreshTokenNotFoundException e) {
+        return new ResponseEntity<>(new Fail("리프레시 토큰이 존재하지 않습니다."), HttpStatus.BAD_REQUEST);
+    }
 
 }

--- a/src/main/java/com/example/trip/advice/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/example/trip/advice/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.trip.advice.exception;
+
+public class RefreshTokenNotFoundException extends RuntimeException {
+    public RefreshTokenNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public RefreshTokenNotFoundException() {
+        super();
+    }
+}

--- a/src/main/java/com/example/trip/advice/exception/TitleNotFoundException.java
+++ b/src/main/java/com/example/trip/advice/exception/TitleNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.trip.advice.exception;
+
+public class TitleNotFoundException extends RuntimeException {
+
+    public TitleNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public TitleNotFoundException() {
+        super();
+    }
+}

--- a/src/main/java/com/example/trip/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/trip/config/WebSecurityConfig.java
@@ -1,12 +1,12 @@
 package com.example.trip.config;
 
 import com.example.trip.jwt.JwtAuthenticationFilter;
+import com.example.trip.jwt.JwtExceptionFilter;
 import com.example.trip.jwt.JwtTokenProvider;
-import com.example.trip.jwt.exceptionhandler.AccessDeniedHandler;
-import com.example.trip.jwt.exceptionhandler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -25,43 +25,30 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
         http
                 .cors()
-                    .and()
+                .and()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT 사용 예정, 세션 필요 X
-                    .and()
+                .and()
                 .csrf().disable() // rest api는 csrf 보안 필요 X
                 .formLogin().disable() // 스프링 시큐리티 login form 사용 X
                 .httpBasic().disable(); // rest api 이므로 기본 설정 사용 X -> 기본 설정은 비인증 시 로그인폼 화면으로 리다이렉트
 
-//                //여기서부터
-//                .csrf().disable() // rest api는 csrf 보안 필요 X
-//                .headers()
-//                    .frameOptions().sameOrigin()
-//                .and()
-//                    .formLogin()
-//
-//                .and()
-//                        .authorizeRequests()
-//                            .antMatchers("/chat/**").permitAll()
-//                            .anyRequest().authenticated(); // 위 antMatchers 이외에는 모든 api 인증 필요
-//                //여기까지
-
 
         http
-               .authorizeRequests()
-               .antMatchers("/api/kakaologin", "/api/googlelogin", "/", "/api/map").permitAll()
-               .anyRequest().authenticated() // 위 antMatchers 이외에는 모든 api 인증 필요
-                    .and()
-               .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
-
-//        http.exceptionHandling()
-//                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()) // 인가 관련
-//                .accessDeniedHandler(new AccessDeniedHandler()); // 인증 관련
+                .authorizeRequests()
+                .antMatchers("/api/kakaologin", "/api/googlelogin", "/", "/api/map").permitAll()
+                .antMatchers(HttpMethod.POST, "/api/token").permitAll()
+//                .antMatchers("**").permitAll()
+                .anyRequest().authenticated() // 위 antMatchers 이외에는 모든 api 인증 필요
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/example/trip/controller/UserController.java
+++ b/src/main/java/com/example/trip/controller/UserController.java
@@ -1,13 +1,11 @@
 package com.example.trip.controller;
 
 import com.example.trip.config.security.UserDetailsImpl;
-import com.example.trip.domain.FeedDetailLoc;
 import com.example.trip.dto.request.UserRequestDto;
 import com.example.trip.dto.response.FeedLocationResponseDto;
 import com.example.trip.dto.response.UserResponseDto;
+import com.example.trip.dto.response.queryprojection.UserInfo;
 import com.example.trip.redis.notification.Notification;
-import com.example.trip.redis.notification.NotifyRepository;
-import com.example.trip.response.*;
 import com.example.trip.service.BookMarkService;
 import com.example.trip.service.RedisService;
 import com.example.trip.service.SocialLoginService;
@@ -25,9 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Controller
@@ -109,7 +105,7 @@ public class UserController {
 
     @GetMapping("/api/user")
     public ResponseEntity<UserResponseDto.Responsev2> userInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        UserResponseDto.GetUser user = userService.findUser(userDetails.getUser().getId());
+        UserInfo user = userService.findUser(userDetails.getUser().getId());
         List<FeedLocationResponseDto.BookMark> bookMarkPlaces = bookMarkService.findBookMarkPlaces(userDetails.getUser().getId());
         return new ResponseEntity<>(UserResponseDto.Responsev2.builder()
                 .result("success")
@@ -117,5 +113,15 @@ public class UserController {
                 .userInfo(user)
                 .bookmark(bookMarkPlaces).build()
                 , HttpStatus.OK);
+    }
+
+    @GetMapping("/api/notification")
+    public ResponseEntity<UserResponseDto.alarmcheck> getNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<Notification> notification = userService.getNotification(userDetails.getUser().getId());
+        return new ResponseEntity<>(UserResponseDto.alarmcheck.builder()
+                .result("success")
+                .msg("알림 정보입니다.")
+                .noti(notification)
+                .build(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/trip/controller/UserController.java
+++ b/src/main/java/com/example/trip/controller/UserController.java
@@ -103,6 +103,7 @@ public class UserController {
                 .msg("회원 탈퇴되었습니다.").build(), HttpStatus.OK);
     }
 
+    // 유저 정보 조회
     @GetMapping("/api/user")
     public ResponseEntity<UserResponseDto.Responsev2> userInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         UserInfo user = userService.findUser(userDetails.getUser().getId());
@@ -116,12 +117,12 @@ public class UserController {
     }
 
     @GetMapping("/api/notification")
-    public ResponseEntity<UserResponseDto.alarmcheck> getNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<UserResponseDto.Notification> getNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<Notification> notification = userService.getNotification(userDetails.getUser().getId());
-        return new ResponseEntity<>(UserResponseDto.alarmcheck.builder()
+        return new ResponseEntity<>(UserResponseDto.Notification.builder()
                 .result("success")
                 .msg("알림 정보입니다.")
-                .noti(notification)
+                .notification(notification)
                 .build(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/trip/controller/UserController.java
+++ b/src/main/java/com/example/trip/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.example.trip.controller;
 
 import com.example.trip.config.security.UserDetailsImpl;
+import com.example.trip.dto.request.TokenRequestDto;
 import com.example.trip.dto.request.UserRequestDto;
 import com.example.trip.dto.response.FeedLocationResponseDto;
+import com.example.trip.dto.response.TokenResponseDto;
 import com.example.trip.dto.response.UserResponseDto;
 import com.example.trip.dto.response.queryprojection.UserInfo;
 import com.example.trip.redis.notification.Notification;
@@ -116,6 +118,7 @@ public class UserController {
                 , HttpStatus.OK);
     }
 
+    // 유저 알림 정보 조회
     @GetMapping("/api/notification")
     public ResponseEntity<UserResponseDto.Notification> getNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<Notification> notification = userService.getNotification(userDetails.getUser().getId());
@@ -123,6 +126,16 @@ public class UserController {
                 .result("success")
                 .msg("알림 정보입니다.")
                 .notification(notification)
+                .build(), HttpStatus.OK);
+    }
+
+    // 토큰 재발급
+    @PostMapping("/api/token")
+    public ResponseEntity<UserResponseDto.reissueToken> reissueToken(@RequestBody TokenRequestDto requestDto) {
+        TokenResponseDto dto = socialLoginService.reissueToken(requestDto);
+        return new ResponseEntity<>(UserResponseDto.reissueToken.builder()
+                .accessToken(dto.getAccessToken())
+                .refreshToken(dto.getRefreshToken())
                 .build(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/trip/domain/FeedLocation.java
+++ b/src/main/java/com/example/trip/domain/FeedLocation.java
@@ -1,18 +1,15 @@
 package com.example.trip.domain;
 
 
-import com.example.trip.dto.request.FeedRequestDto;
-import lombok.AccessLevel;
-import com.example.trip.dto.request.FeedRequestDto;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import javax.persistence.*;
 import java.util.List;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FeedLocation {
 

--- a/src/main/java/com/example/trip/dto/request/FeedRequestDto.java
+++ b/src/main/java/com/example/trip/dto/request/FeedRequestDto.java
@@ -2,9 +2,8 @@ package com.example.trip.dto.request;
 
 import com.example.trip.domain.FeedDetail;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.sun.istack.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -14,6 +13,7 @@ import java.util.List;
 public class FeedRequestDto {
 
     @Getter
+    @AllArgsConstructor
     public static class FeedRequestRegisterDto {
         @NotBlank
         private String title;
@@ -30,6 +30,7 @@ public class FeedRequestDto {
     }
 
     @Getter
+    @AllArgsConstructor
     public static class FeedRequestModifyDto {
         @NotBlank
         private String title;

--- a/src/main/java/com/example/trip/dto/request/TokenRequestDto.java
+++ b/src/main/java/com/example/trip/dto/request/TokenRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.trip.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/trip/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/example/trip/dto/response/TokenResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.trip.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/trip/dto/response/UserResponseDto.java
+++ b/src/main/java/com/example/trip/dto/response/UserResponseDto.java
@@ -134,5 +134,6 @@ public class UserResponseDto {
     @Getter
     public static class reissueToken {
         private String accessToken;
+        private String refreshToken;
     }
 }

--- a/src/main/java/com/example/trip/dto/response/UserResponseDto.java
+++ b/src/main/java/com/example/trip/dto/response/UserResponseDto.java
@@ -127,7 +127,7 @@ public class UserResponseDto {
     public static class Notification {
         private String result;
         private String msg;
-        private List<Notification> notification;
+        private List<com.example.trip.redis.notification.Notification> notification;
     }
 
     @Builder

--- a/src/main/java/com/example/trip/dto/response/UserResponseDto.java
+++ b/src/main/java/com/example/trip/dto/response/UserResponseDto.java
@@ -2,7 +2,7 @@ package com.example.trip.dto.response;
 
 import com.example.trip.domain.Image;
 import com.example.trip.domain.Role;
-import com.example.trip.domain.User;
+import com.example.trip.dto.response.queryprojection.UserInfo;
 import com.example.trip.redis.notification.Notification;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -101,26 +101,12 @@ public class UserResponseDto {
         private Long userId;
     }
 
-    @AllArgsConstructor
-    @Getter
-    public static class GetUser {
-        private Long userId;
-        private String userName;
-        private String userProfileImage;
-
-        public GetUser(User user) {
-            this.userId = user.getId();
-            this.userName = user.getUsername();
-            this.userProfileImage = user.getImage().getFile_store_course();
-        }
-    }
-
     @Builder
     @Getter
     public static class Responsev2 {
         private String result;
         private String msg;
-        private UserResponseDto.GetUser userInfo;
+        private UserInfo userInfo;
 //        private List<Notification> notificationInfo;
         private List<FeedLocationResponseDto.BookMark> bookmark;
 
@@ -134,5 +120,19 @@ public class UserResponseDto {
         private boolean first;
         private TokenInfo tokens;
         private UserProfile userInfo;
+    }
+
+    @Builder
+    @Getter
+    public static class Notification {
+        private String result;
+        private String msg;
+        private List<Notification> notification;
+    }
+
+    @Builder
+    @Getter
+    public static class reissueToken {
+        private String accessToken;
     }
 }

--- a/src/main/java/com/example/trip/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trip/jwt/JwtAuthenticationFilter.java
@@ -4,58 +4,30 @@ package com.example.trip.jwt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.filter.GenericFilterBean;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private static final Long AccessTokenValidTime = 30 * 60 * 1000L; // 30분
 
     @Override
-    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        String accessToken = jwtTokenProvider.resolveAccessToken(request);
-        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
-
+    public void doFilter(ServletRequest request,
+                         ServletResponse response,
+                         FilterChain filterChain) throws IOException, ServletException {
+        // 헤더에서 JWT 를 받아옵니다.
+        String token = jwtTokenProvider.resolveAccessToken((HttpServletRequest) request);
         // 유효한 토큰인지 확인합니다.
-        if (accessToken != null) {
-            // 어세스 토큰이 유효한 상황
-            if (jwtTokenProvider.validateToken(accessToken)) {
-                this.setAuthentication(accessToken);
-            }
-            // 어세스 토큰이 만료된 상황 | 리프레시 토큰 또한 존재하는 상황
-            else if (!jwtTokenProvider.validateToken(accessToken) && refreshToken != null) {
-                // 재발급 후, 컨텍스트에 다시 넣기
-                /// 리프레시 토큰 검증
-                boolean validateRefreshToken = jwtTokenProvider.validateToken(refreshToken);
-                /// 리프레시 토큰 저장소 존재유무 확인
-                boolean isRefreshToken = jwtTokenProvider.existsRefreshToken(refreshToken);
-                if (validateRefreshToken && isRefreshToken) {
-                    /// 리프레시 토큰으로 sns계정 아이디 정보 가져오기
-                    String snsaccountId = jwtTokenProvider.getUserPk(refreshToken);
-                    /// 토큰 발급
-                    String newAccessToken = jwtTokenProvider.createToken(snsaccountId, AccessTokenValidTime);
-                    /// 헤더에 어세스 토큰 추가
-                    jwtTokenProvider.setHeaderAccessToken(response, newAccessToken);
-                    /// 컨텍스트에 넣기
-                    this.setAuthentication(newAccessToken);
-                }
-            }
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효하면 토큰으로부터 유저 정보를 받아옵니다.
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            // SecurityContext 에 Authentication 객체를 저장합니다.
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         filterChain.doFilter(request, response);
-    }
-
-    // SecurityContext 에 Authentication 객체를 저장합니다.
-    public void setAuthentication(String token) {
-        // 토큰으로부터 유저 정보를 받아옵니다.
-        Authentication authentication = jwtTokenProvider.getAuthentication(token);
-        // SecurityContext 에 Authentication 객체를 저장합니다.
-        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/src/main/java/com/example/trip/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/example/trip/jwt/JwtExceptionFilter.java
@@ -1,0 +1,42 @@
+package com.example.trip.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.json.JSONObject;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            sendTokenException(HttpStatus.UNAUTHORIZED, response);
+        }
+    }
+
+    private void sendTokenException(HttpStatus httpstatus, HttpServletResponse response) throws IOException {
+        response.setStatus(httpstatus.value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        JSONObject body = new JSONObject();
+        body.put("status", 401);
+        body.put("error message", "ACCESSTOKEN 유효기간 만료, 재발급 필요");
+
+        PrintWriter out = response.getWriter();
+        out.print(body);
+    }
+}

--- a/src/main/java/com/example/trip/repository/feed/FeedCustomRepository.java
+++ b/src/main/java/com/example/trip/repository/feed/FeedCustomRepository.java
@@ -1,0 +1,9 @@
+package com.example.trip.repository.feed;
+
+import com.example.trip.dto.response.FeedResponseDto;
+
+import java.util.List;
+
+public interface FeedCustomRepository {
+    List<FeedResponseDto.GetFeed> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/trip/repository/feed/FeedCustomRepositoryImpl.java
+++ b/src/main/java/com/example/trip/repository/feed/FeedCustomRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.example.trip.repository.feed;
+
+import com.example.trip.dto.response.*;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.trip.domain.QFeedLocation.feedLocation;
+import static com.example.trip.domain.QFeedDetailLoc.feedDetailLoc;
+import static com.example.trip.domain.QFeedDetailLocImg.feedDetailLocImg;
+import static com.example.trip.domain.QFeed.feed;
+import static com.example.trip.domain.QFeedDetail.feedDetail;
+import static com.example.trip.domain.QLikes.likes;
+import static com.example.trip.domain.QUser.user;
+import static com.example.trip.domain.QFeedComment.feedComment;
+
+@Repository
+public class FeedCustomRepositoryImpl implements FeedCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public FeedCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public List<FeedResponseDto.GetFeed> findByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(FeedResponseDto.GetFeed.class,
+                        feed.id, feed.title, feed.travelStart, feed.travelEnd,
+                        Projections.list(Projections.constructor(FeedDetailResponseDto.GetFeedDetail.class,
+                                feedDetail.day,
+                                Projections.list(Projections.constructor(FeedDetailLocResponseDto.GetFeedDetailLoc.class,
+                                        feedDetailLoc.id, feedDetailLoc.createdAt, feedDetailLoc.feedLocation.name,
+                                        Projections.list(Projections.constructor(FeedDetailLocImgResponseDto.ImgUrl.class, feedDetailLocImg.imgUrl)),
+                                        Projections.list(Projections.constructor(LikesResponseDto.GetUserId.class, likes.user.id)),
+                                        Projections.constructor(UserResponseDto.GetUser.class, feed.user),
+                                        feedDetailLoc.memo,
+                                        Projections.list(Projections.constructor(FeedCommentResponseDto.GetComment.class, feedComment.id,
+                                                Projections.constructor(UserResponseDto.GetUser.class, feedComment.user),
+                                                feedComment.content))))
+                        )),
+                        feed.feedDetail))
+                .from(feed)
+                .leftJoin(user).on(feed.user.id.eq(user.id))
+                .leftJoin(feedDetail).on(feed.id.eq(feedDetail.feed.id))
+                .leftJoin(feedDetailLoc).on(feedDetail.id.eq(feedDetailLoc.feedDetail.id))
+                .leftJoin(feedDetailLocImg).on(feedDetailLoc.id.eq(feedDetailLocImg.feedDetailLoc.id))
+                .leftJoin(likes).on(likes.feedDetailLoc.id.eq(feedDetailLoc.id))
+                .leftJoin(user).on(user.id.eq(likes.user.id))
+                .leftJoin(feedComment).on(feedComment.feedDetailLoc.id.eq(feedDetailLoc.id))
+                .leftJoin(user).on(user.id.eq(feedComment.user.id))
+                .where(feed.user.id.eq(userId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/trip/repository/feed/FeedRepository.java
+++ b/src/main/java/com/example/trip/repository/feed/FeedRepository.java
@@ -1,0 +1,20 @@
+package com.example.trip.repository.feed;
+
+import com.example.trip.domain.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRepository {
+    @Query("select f from Feed f left join fetch f.user u where u.id = :userId and f.id = :feedId")
+    Optional<Feed> FindFeedByUserId(Long userId, Long feedId);
+
+//    List<Feed> findByUserId(Long userId, Pageable pageable);
+//    List<Feed> findByUserId(Long userId);
+
+    @Query("select f from Feed f where f.id = ?1 and f.user.id = ?2")
+    List<Feed> findByIdAndUserId(Long feedId, Long userId);
+
+}

--- a/src/main/java/com/example/trip/service/SocialLoginService.java
+++ b/src/main/java/com/example/trip/service/SocialLoginService.java
@@ -1,8 +1,11 @@
 package com.example.trip.service;
 
 import com.example.trip.domain.User;
+import com.example.trip.dto.request.TokenRequestDto;
+import com.example.trip.dto.response.TokenResponseDto;
 import com.example.trip.dto.response.UserResponseDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jdk.nashorn.internal.parser.Token;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
@@ -47,4 +50,6 @@ public interface SocialLoginService {
     void deleteAccount(String socialaccountId);
 
     void checkNoSameUsername(String username);
+
+    TokenResponseDto reissueToken(TokenRequestDto requestDto);
 }

--- a/src/main/java/com/example/trip/service/UserService.java
+++ b/src/main/java/com/example/trip/service/UserService.java
@@ -1,12 +1,17 @@
 package com.example.trip.service;
 
 import com.example.trip.dto.response.UserResponseDto;
+import com.example.trip.dto.response.queryprojection.UserInfo;
+import com.example.trip.redis.notification.Notification;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 public interface UserService {
 
-    UserResponseDto.GetUser findUser(Long userId);
+    UserInfo findUser(Long userId);
 
     void registerLog(HttpServletRequest request, UserResponseDto.KakaoLogin loginRequestDto);
+
+    List<Notification> getNotification(Long userId);
 }

--- a/src/main/java/com/example/trip/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/trip/service/impl/UserServiceImpl.java
@@ -4,13 +4,18 @@ import com.example.trip.advice.exception.UserNotFoundException;
 import com.example.trip.domain.LoginLog;
 import com.example.trip.domain.User;
 import com.example.trip.dto.response.UserResponseDto;
+import com.example.trip.dto.response.queryprojection.UserInfo;
+import com.example.trip.redis.notification.Notification;
 import com.example.trip.repository.LoginLogRepository;
 import com.example.trip.repository.UserRepository;
 import com.example.trip.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -20,9 +25,13 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final LoginLogRepository loginLogRepository;
 
-    public UserResponseDto.GetUser findUser(Long userId) {
+    private static final String NOTIFICATION = "NOTIFICATION";
+    private final RedisTemplate<String, Object> redisTemplate;
+    private HashOperations<String, String, List<Notification>> opsHashNotification;
+
+    public UserInfo findUser(Long userId) {
         Optional<User> user = Optional.ofNullable(userRepository.findById(userId).orElseThrow(UserNotFoundException::new));
-        return new UserResponseDto.GetUser(user.get());
+        return new UserInfo(user.get());
     }
 
     public void registerLog(HttpServletRequest request, UserResponseDto.KakaoLogin loginRequestDto) {
@@ -33,5 +42,10 @@ public class UserServiceImpl implements UserService {
                 .login_ip(remoteAddr)
                 .user(user.get()).build();
         loginLogRepository.save(log);
+    }
+
+    public List<Notification> getNotification(Long userId) {
+        opsHashNotification = redisTemplate.opsForHash();
+        return opsHashNotification.get(NOTIFICATION, "USER" + userId);
     }
 }

--- a/src/test/java/com/example/trip/domain/FeedCommentTest.java
+++ b/src/test/java/com/example/trip/domain/FeedCommentTest.java
@@ -1,0 +1,79 @@
+package com.example.trip.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static com.example.trip.domain.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedCommentTest {
+
+    private FeedDetailLoc feedDetailLoc;
+    private  User user;
+
+    @BeforeEach
+    void setup() {
+
+       user = User.builder()
+                .email("kim@naver.com")
+                .username("babo")
+                .password("1234")
+                .memberstatus(true)
+                .socialaccountId("KAKAO_1234")
+                .role(USER)
+                .image(Image.builder().build())
+                .build();
+
+        Feed feed = Feed.builder()
+                .title("제주도 여행")
+                .travelStart(LocalDateTime.of(2020, 1, 23, 1, 33))
+                .travelEnd(LocalDateTime.of(2021, 1, 23, 1, 33))
+                .feedDetail(null)
+                .build();
+
+
+        FeedDetail feedDetail = FeedDetail.builder()
+                .feed(feed)
+                .feedDetailLoc(null)
+                .day("1일차")
+                .build();
+
+        FeedLocation feedLocation = FeedLocation.builder()
+                .name("감귤농장")
+                .latitude("100.356")
+                .longitude("46.87")
+                .placeAddress("서귀포시")
+                .build();
+
+        feedDetailLoc = FeedDetailLoc.builder()
+                .memo("날씨가 좋아서 더 좋았던 제주도")
+                .feedDetail(feedDetail)
+                .feedLocation(feedLocation)
+                .build();
+    }
+
+    @Test
+    @DisplayName("피드댓글생성 - 정상케이스")
+    void createFeedComment_normal() {
+        //given
+        FeedDetailLoc feedDetailLoc = this.feedDetailLoc;
+        String content = "나랑 같이 가자 제주도";
+        User user1 = user;
+
+        //when
+        FeedComment feedComment = FeedComment.builder()
+                .feedDetailLoc(feedDetailLoc)
+                .content(content)
+                .user(user1)
+                .build();
+
+        //then
+        assertNull(feedComment.getId());
+        assertEquals(feedDetailLoc, feedComment.getFeedDetailLoc());
+        assertEquals(content, feedComment.getContent());
+        assertEquals(user1, feedComment.getUser());
+    }
+}

--- a/src/test/java/com/example/trip/domain/FeedDetailLocImgTest.java
+++ b/src/test/java/com/example/trip/domain/FeedDetailLocImgTest.java
@@ -1,0 +1,65 @@
+package com.example.trip.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedDetailLocImgTest {
+
+    private FeedDetailLoc feedDetailLoc;
+
+    @BeforeEach
+    void setup() {
+        Feed feed = Feed.builder()
+                .title("제주도 여행")
+                .travelStart(LocalDateTime.of(2020, 1, 23, 1, 33))
+                .travelEnd(LocalDateTime.of(2021, 1, 23, 1, 33))
+                .feedDetail(null)
+                .build();
+
+        FeedDetail feedDetail = FeedDetail.builder()
+                .feed(feed)
+                .feedDetailLoc(null)
+                .day("1일차")
+                .build();
+
+        FeedLocation feedLocation = FeedLocation.builder()
+                .name("감귤농장")
+                .latitude("100.356")
+                .longitude("46.87")
+                .placeAddress("서귀포시")
+                .build();
+
+        feedDetailLoc = FeedDetailLoc.builder()
+                .memo("날씨가 좋아서 더 좋았던 제주도")
+                .feedDetail(feedDetail)
+                .feedLocation(feedLocation)
+                .build();
+    }
+
+    @Test
+    @DisplayName("피드상세위치이미지생성 - 정상케이스")
+    void createFeedDetailLocImg_normal() {
+        //given
+        FeedDetailLoc location = feedDetailLoc;
+        String filename = "cloudimage.jpg";
+        String imgUrl = "image/cloudimage.jpg";
+
+        //when
+        FeedDetailLocImg feedDetailLocImg = FeedDetailLocImg.builder()
+                .feedDetailLoc(location)
+                .fileName(filename)
+                .imgUrl(imgUrl)
+                .build();
+
+        //then
+        assertNull(feedDetailLocImg.getId());
+        assertEquals(location, feedDetailLocImg.getFeedDetailLoc());
+        assertEquals(filename, feedDetailLocImg.getFileName());
+        assertEquals(imgUrl, feedDetailLocImg.getImgUrl());
+    }
+}

--- a/src/test/java/com/example/trip/domain/FeedDetailLocTest.java
+++ b/src/test/java/com/example/trip/domain/FeedDetailLocTest.java
@@ -1,0 +1,66 @@
+package com.example.trip.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedDetailLocTest {
+
+    FeedDetail feedDetail;
+    FeedLocation feedLocation;
+
+    @BeforeEach
+    void setup() {
+        Feed feed = Feed.builder()
+                .title("제주도 여행")
+                .travelStart(LocalDateTime.of(2020, 1, 23, 1, 33))
+                .travelEnd(LocalDateTime.of(2021, 1, 23, 1, 33))
+                .feedDetail(null)
+                .build();
+
+
+        feedDetail = FeedDetail.builder()
+                .feed(feed)
+                .feedDetailLoc(null)
+                .day("1일차")
+                .build();
+
+        feedLocation = FeedLocation.builder()
+                .name("감귤농장")
+                .latitude("100.356")
+                .longitude("46.87")
+                .placeAddress("서귀포시")
+                .build();
+
+    }
+
+    @Test
+    @DisplayName("피드상세위치생성 - 정상케이스")
+    void createFeedDetailLoc_normal() {
+
+        // given
+        String memo = "날씨가 좋아서 더 좋았던 제주도";
+        FeedDetail detail = feedDetail;
+        FeedLocation location = feedLocation;
+
+        // when
+        FeedDetailLoc feedDetailLoc = FeedDetailLoc.builder()
+                .memo(memo)
+                .feedDetail(detail)
+                .feedLocation(location)
+                .build();
+
+        // then
+        assertNull(feedDetailLoc.getId());
+        assertNull(feedDetailLoc.getFeedDetailLocImg());
+        assertNull(feedDetailLoc.getLikes());
+        assertNull(feedDetailLoc.getFeedComments());
+        assertEquals(memo, feedDetailLoc.getMemo());
+        assertEquals(detail, feedDetailLoc.getFeedDetail());
+        assertEquals(location, feedDetailLoc.getFeedLocation());
+    }
+}

--- a/src/test/java/com/example/trip/domain/FeedDetailTest.java
+++ b/src/test/java/com/example/trip/domain/FeedDetailTest.java
@@ -1,0 +1,58 @@
+package com.example.trip.domain;
+
+import com.example.trip.dto.request.FeedRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedDetailTest {
+
+    private Feed feed;
+
+    @BeforeEach
+    void setup() {
+        String title = "제주도 여행";
+        LocalDateTime travelStart = LocalDateTime.of(2020, 1, 23, 1, 33);
+        LocalDateTime travelEnd = LocalDateTime.of(2021, 1, 23, 1, 33);
+        List<FeedDetail> feedDetail = null;
+
+        FeedRequestDto.FeedRequestRegisterDto dto = new FeedRequestDto.FeedRequestRegisterDto(
+                title,
+                travelStart,
+                travelEnd,
+                feedDetail
+        );
+
+        feed = Feed.builder()
+                .title(dto.getTitle())
+                .travelStart(dto.getTravelStart())
+                .travelEnd(dto.getTravelEnd())
+                .feedDetail(null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("피드상세생성 - 정상케이스")
+    void createFeedDetail_normal() {
+
+        //given
+        Feed feed1 = feed;
+        String day = "1일차";
+
+        //when
+        FeedDetail feedDetail = FeedDetail.builder()
+                .feed(feed1)
+                .day(day)
+                .build();
+
+        //then
+        assertNull(feedDetail.getId());
+        assertEquals(feed1, feedDetail.getFeed());
+        assertNull(feedDetail.getFeedDetailLoc());
+        assertEquals(day, feedDetail.getDay());
+    }
+}

--- a/src/test/java/com/example/trip/domain/FeedLocationTest.java
+++ b/src/test/java/com/example/trip/domain/FeedLocationTest.java
@@ -1,0 +1,37 @@
+package com.example.trip.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedLocationTest {
+
+    @Test
+    @DisplayName("위치생성 - 정상케이스")
+    void createFeedLocation_normal() {
+        //given
+        String name = "롯데월드";
+        String latitude = "127.668";
+        String longitude = "87.667";
+        String placeAddress = "서울특별시 잠실";
+
+        //when
+        FeedLocation feedLocation = FeedLocation.builder()
+                .name(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .placeAddress(placeAddress)
+                .build();
+
+        //then
+        assertNull(feedLocation.getId());
+        assertNull(feedLocation.getFeedDetailLocs());
+        assertNull(feedLocation.getBookMarks());
+        assertEquals(name, feedLocation.getName());
+        assertEquals(latitude, feedLocation.getLatitude());
+        assertEquals(longitude, feedLocation.getLongitude());
+        assertEquals(placeAddress, feedLocation.getPlaceAddress());
+    }
+
+}

--- a/src/test/java/com/example/trip/domain/FeedTest.java
+++ b/src/test/java/com/example/trip/domain/FeedTest.java
@@ -1,0 +1,86 @@
+package com.example.trip.domain;
+
+import com.example.trip.dto.request.FeedRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.trip.domain.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeedTest {
+
+    @Test
+    @DisplayName("피드생성 - 정상케이스")
+    void createFeed_Normal() {
+
+        //given
+        User user = User.builder()
+                .email("kim@naver.com")
+                .username("babo")
+                .password("1234")
+                .memberstatus(true)
+                .socialaccountId("KAKAO_1234")
+                .role(USER)
+                .image(Image.builder().build())
+                .build();
+
+        String title = "제주도 여행";
+        LocalDateTime travelStart = LocalDateTime.of(2020, 1, 23, 1, 33);
+        LocalDateTime travelEnd = LocalDateTime.of(2021, 1, 23, 1, 33);
+        List<FeedDetail> feedDetail = null;
+
+        FeedRequestDto.FeedRequestRegisterDto dto = new FeedRequestDto.FeedRequestRegisterDto(
+                title,
+                travelStart,
+                travelEnd,
+                feedDetail
+        );
+
+        //when
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(dto.getTitle())
+                .travelStart(dto.getTravelStart())
+                .travelEnd(dto.getTravelEnd())
+                .feedDetail(null)
+                .build();
+
+        //then
+        assertNull(feed.getId());
+        assertNull(feed.getFeedDetail());
+        assertEquals(user, feed.getUser());
+        assertEquals(title, feed.getTitle());
+        assertEquals(travelStart, feed.getTravelStart());
+        assertEquals(travelEnd, feed.getTravelEnd());
+
+    }
+
+    @Test
+    @DisplayName("피드수정 - 정상케이스")
+    void updateFeed_normal() {
+        //given
+        Feed feed = Feed.builder()
+                .title("제주도 여행")
+                .travelStart(LocalDateTime.of(2020, 1, 23, 1, 33))
+                .travelEnd(LocalDateTime.of(2021, 1, 23, 1, 33))
+                .feedDetail(null)
+                .build();
+
+        FeedRequestDto.FeedRequestModifyDto dto = new FeedRequestDto.FeedRequestModifyDto(
+                "울릉도 여행",
+                LocalDateTime.of(2020, 2, 23, 1, 33),
+                LocalDateTime.of(2021, 1, 23, 1, 33),
+                null
+        );
+
+        //when
+        feed.update(dto);
+
+        //then
+        assertEquals(feed.getTitle(), dto.getTitle());
+        assertEquals(feed.getTravelStart(), dto.getTravelStart());
+        assertEquals(feed.getTravelEnd(), dto.getTravelEnd());
+    }
+}

--- a/src/test/java/com/example/trip/service/impl/FeedCommentServiceImplTest.java
+++ b/src/test/java/com/example/trip/service/impl/FeedCommentServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.example.trip.service.impl;
+
+import com.example.trip.domain.FeedComment;
+import com.example.trip.domain.FeedDetailLoc;
+import com.example.trip.domain.Image;
+import com.example.trip.domain.User;
+import com.example.trip.dto.request.FeedRequestDto;
+import com.example.trip.repository.CommentRepository;
+import com.example.trip.repository.FeedDetailLocRepository;
+import com.example.trip.repository.LikeRepository;
+import com.example.trip.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.trip.domain.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeedCommentServiceImplTest {
+
+    @Mock
+    FeedDetailLocRepository feedDetailLocRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    FeedDetailLoc feedDetailLoc;
+
+    User user;
+
+    @BeforeEach
+    void setup() {
+        user = User.builder()
+                .email("kim@naver.com")
+                .username("babo")
+                .password("1234")
+                .memberstatus(true)
+                .socialaccountId("KAKAO_1234")
+                .role(USER)
+                .image(Image.builder().build())
+                .build();
+
+
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        userRepository.save(user);
+
+        List<FeedDetailLoc> detailLocs = new ArrayList<>();
+
+        feedDetailLoc = FeedDetailLoc.builder()
+                .memo("감귤농장에서 귤 따기")
+                .build();
+
+        detailLocs.add(feedDetailLoc);
+
+        when(feedDetailLocRepository.saveAll(detailLocs)).thenReturn(detailLocs);
+        feedDetailLocRepository.saveAll(detailLocs);
+    }
+
+    @Test
+    @DisplayName("댓글 생성 - 정상 케이스")
+    void createComment_normal() {
+        //given
+        FeedRequestDto.FeedRequestCommentRegisterDto dto = new FeedRequestDto.FeedRequestCommentRegisterDto("저도 가보고 싶어요~");
+
+        FeedComment feedComment = FeedComment.builder()
+                .feedDetailLoc(feedDetailLoc)
+                .user(user)
+                .content(dto.getContent())
+                .build();
+
+        when(commentRepository.save(feedComment)).thenReturn(feedComment);
+
+        //when
+        FeedComment comment = commentRepository.save(feedComment);
+
+        //then
+        assertEquals("저도 가보고 싶어요~", comment.getContent());
+        assertEquals("감귤농장에서 귤 따기", comment.getFeedDetailLoc().getMemo());
+        assertEquals("babo", comment.getUser().getUsername());
+        assertEquals("kim@naver.com", comment.getUser().getEmail());
+        assertEquals("KAKAO_1234", comment.getUser().getSocialaccountId());
+        assertEquals(USER, comment.getUser().getRole());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 - 정상 케이스")
+    void modifyComment_normal() {
+        //given
+        FeedRequestDto.FeedRequestCommentRegisterDto dtoCreate = new FeedRequestDto.FeedRequestCommentRegisterDto("저도 가보고 싶어요~");
+
+        FeedComment feedComment = FeedComment.builder()
+                .feedDetailLoc(feedDetailLoc)
+                .user(user)
+                .content(dtoCreate.getContent())
+                .build();
+
+        when(commentRepository.save(feedComment)).thenReturn(feedComment);
+        FeedComment comment = commentRepository.save(feedComment);
+
+        FeedRequestDto.FeedRequestCommentModifyDto dtoModify = new FeedRequestDto.FeedRequestCommentModifyDto("다음에 함께 가요!");
+
+        //when
+        comment.update(dtoModify);
+
+        //then
+        assertEquals("다음에 함께 가요!", comment.getContent());
+        assertNotEquals("저도 가보고 싶어요~", comment.getContent());
+    }
+
+}

--- a/src/test/java/com/example/trip/service/impl/FeedServiceImplTest.java
+++ b/src/test/java/com/example/trip/service/impl/FeedServiceImplTest.java
@@ -1,0 +1,393 @@
+package com.example.trip.service.impl;
+
+import com.example.trip.domain.*;
+import com.example.trip.dto.request.FeedRequestDto;
+import com.example.trip.repository.*;
+import com.example.trip.repository.feed.FeedRepository;
+import com.example.trip.repository.feedlocation.FeedLocationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.trip.domain.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceImplTest {
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    FeedRepository feedRepository;
+    @Mock
+    FeedDetailRepository feedDetailRepository;
+    @Mock
+    FeedDetailLocRepository feedDetailLocRepository;
+    @Mock
+    FeedDetailLocImgRepository feedDetailLocImgRepository;
+    @Mock
+    FeedLocationRepository feedLocationRepository;
+
+    private User user;
+    private User save;
+
+    @BeforeEach
+    void setup() {
+        user = User.builder()
+                .email("kim@naver.com")
+                .username("babo")
+                .password("1234")
+                .memberstatus(true)
+                .socialaccountId("KAKAO_1234")
+                .role(USER)
+                .image(Image.builder().build())
+                .build();
+
+
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        save = userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("피드 저장")
+    void createFeed_normal() {
+        //given
+        FeedRequestDto.FeedRequestRegisterDto feedRequestRegisterDto = new FeedRequestDto.FeedRequestRegisterDto(
+                "제주도 여행기",
+                LocalDateTime.of(2020, 1, 23, 1, 00),
+                LocalDateTime.of(2020, 1, 30, 1, 00),
+                null);
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(feedRequestRegisterDto.getTitle())
+                .travelStart(feedRequestRegisterDto.getTravelStart())
+                .travelEnd(feedRequestRegisterDto.getTravelEnd())
+                .build();
+
+        //when
+        when(feedRepository.save(any(Feed.class))).thenReturn(feed);
+
+        Feed result = feedRepository.save(feed);
+
+        //then
+        assertEquals(save.getId(), result.getUser().getId());
+        assertEquals(feedRequestRegisterDto.getTitle(), feed.getTitle());
+        assertEquals(feedRequestRegisterDto.getTravelStart(), feed.getTravelStart());
+        assertEquals(feedRequestRegisterDto.getTravelEnd(), feed.getTravelEnd());
+    }
+
+    @Test
+    @DisplayName("피드 상세 저장")
+    void createFeedDetail_normal() {
+        //given
+        List<FeedDetail> details = new ArrayList<>();
+
+        FeedDetail feedDetail_1 = FeedDetail.builder()
+                .day("1일차")
+                .build();
+
+        FeedDetail feedDetail_2 = FeedDetail.builder()
+                .day("2일차")
+                .build();
+
+        FeedDetail feedDetail_3 = FeedDetail.builder()
+                .day("3일차")
+                .build();
+
+        details.add(feedDetail_1);
+        details.add(feedDetail_2);
+        details.add(feedDetail_3);
+
+        FeedRequestDto.FeedRequestRegisterDto feedRequestRegisterDto = new FeedRequestDto.FeedRequestRegisterDto(
+                "제주도 여행기",
+                LocalDateTime.of(2020, 1, 23, 1, 00),
+                LocalDateTime.of(2020, 1, 30, 1, 00),
+                details);
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(feedRequestRegisterDto.getTitle())
+                .travelStart(feedRequestRegisterDto.getTravelStart())
+                .travelEnd(feedRequestRegisterDto.getTravelEnd())
+                .build();
+
+        when(feedRepository.save(any(Feed.class))).thenReturn(feed);
+        Feed saveFeed = feedRepository.save(feed);
+
+        when(feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail())).thenReturn(details);
+
+        feedRequestRegisterDto.getFeedDetail().stream().forEach(x -> x.setFeed(saveFeed));
+
+        //when
+        feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail());
+
+        //then
+        assertEquals(3, feedRequestRegisterDto.getFeedDetail().size());
+        assertEquals(details.indexOf(0), feedRequestRegisterDto.getFeedDetail().indexOf(0));
+        assertEquals(details.indexOf(1), feedRequestRegisterDto.getFeedDetail().indexOf(1));
+        assertEquals(details.indexOf(2), feedRequestRegisterDto.getFeedDetail().indexOf(2));
+
+    }
+
+    @Test
+    @DisplayName("게시글 저장")
+    void createFeedDetailLoc_normal() {
+        //given
+        List<FeedDetailLoc> detailLocs = new ArrayList<>();
+
+        FeedDetailLoc feedDetailLoc_1 = FeedDetailLoc.builder()
+                .memo("감귤농장에서 귤 따기")
+                .build();
+
+        FeedDetailLoc feedDetailLoc_2 = FeedDetailLoc.builder()
+                .memo("맛있는 해산물 시장")
+                .build();
+
+        detailLocs.add(feedDetailLoc_1);
+        detailLocs.add(feedDetailLoc_2);
+
+        List<FeedDetail> details = new ArrayList<>();
+
+        FeedDetail feedDetail_1 = FeedDetail.builder()
+                .feedDetailLoc(detailLocs)
+                .day("1일차")
+                .build();
+
+        details.add(feedDetail_1);
+
+        FeedRequestDto.FeedRequestRegisterDto feedRequestRegisterDto = new FeedRequestDto.FeedRequestRegisterDto(
+                "제주도 여행기",
+                LocalDateTime.of(2020, 1, 23, 1, 00),
+                LocalDateTime.of(2020, 1, 30, 1, 00),
+                details);
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(feedRequestRegisterDto.getTitle())
+                .travelStart(feedRequestRegisterDto.getTravelStart())
+                .travelEnd(feedRequestRegisterDto.getTravelEnd())
+                .build();
+
+        when(feedRepository.save(any(Feed.class))).thenReturn(feed);
+        Feed saveFeed = feedRepository.save(feed);
+
+        feedRequestRegisterDto.getFeedDetail().stream().forEach(x -> x.setFeed(saveFeed));
+        when(feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail())).thenReturn(details);
+        feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail());
+
+        feedRequestRegisterDto.getFeedDetail()
+                .stream()
+                .forEach(x -> x.getFeedDetailLoc()
+                        .forEach(y -> y.setFeedDetail(x)));
+        List<FeedDetailLoc> feedDetailLocs = details.stream().map(FeedDetail::getFeedDetailLoc).flatMap(Collection::stream).collect(Collectors.toList());
+
+        when(feedDetailLocRepository.saveAll(feedDetailLocs)).thenReturn(detailLocs);
+
+        //when
+        feedDetailLocRepository.saveAll(feedDetailLocs);
+
+        //then
+        assertEquals(detailLocs.size(), feedDetailLocs.size());
+        assertEquals(detailLocs.indexOf(0), feedDetailLocs.indexOf(0));
+        assertEquals(detailLocs.indexOf(1), feedDetailLocs.indexOf(1));
+    }
+
+    @Test
+    @DisplayName("위치 저장")
+    void createFeedLocation_normal() {
+        //given
+        List<FeedLocation> locations = new ArrayList<>();
+
+        FeedLocation feedLocation_1 = FeedLocation.builder()
+                .name("감귤농장")
+                .placeAddress("제주도 서귀포시")
+                .latitude("100.684")
+                .longitude("59.666")
+                .build();
+
+        FeedLocation feedLocation_2 = FeedLocation.builder()
+                .name("해산물 시장")
+                .placeAddress("제주도 제주시")
+                .latitude("102.555")
+                .longitude("80.666")
+                .build();
+
+        locations.add(feedLocation_1);
+        locations.add(feedLocation_2);
+
+
+
+        List<FeedDetailLoc> detailLocs = new ArrayList<>();
+
+        FeedDetailLoc feedDetailLoc_1 = FeedDetailLoc.builder()
+                .memo("감귤농장에서 귤 따기")
+                .feedLocation(feedLocation_1)
+                .build();
+
+        FeedDetailLoc feedDetailLoc_2 = FeedDetailLoc.builder()
+                .memo("맛있는 해산물 시장")
+                .feedLocation(feedLocation_2)
+                .build();
+
+        detailLocs.add(feedDetailLoc_1);
+        detailLocs.add(feedDetailLoc_2);
+
+        List<FeedDetail> details = new ArrayList<>();
+
+        FeedDetail feedDetail_1 = FeedDetail.builder()
+                .feedDetailLoc(detailLocs)
+                .day("1일차")
+                .build();
+
+        details.add(feedDetail_1);
+
+        FeedRequestDto.FeedRequestRegisterDto feedRequestRegisterDto = new FeedRequestDto.FeedRequestRegisterDto(
+                "제주도 여행기",
+                LocalDateTime.of(2020, 1, 23, 1, 00),
+                LocalDateTime.of(2020, 1, 30, 1, 00),
+                details);
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(feedRequestRegisterDto.getTitle())
+                .travelStart(feedRequestRegisterDto.getTravelStart())
+                .travelEnd(feedRequestRegisterDto.getTravelEnd())
+                .build();
+
+        when(feedRepository.save(any(Feed.class))).thenReturn(feed);
+        Feed saveFeed = feedRepository.save(feed);
+
+        feedRequestRegisterDto.getFeedDetail().stream().forEach(x -> x.setFeed(saveFeed));
+        when(feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail())).thenReturn(details);
+        List<FeedDetail> feedDetails = feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail());
+
+        feedRequestRegisterDto.getFeedDetail()
+                .stream()
+                .forEach(x -> x.getFeedDetailLoc()
+                        .forEach(y -> y.setFeedDetail(x)));
+        List<FeedDetailLoc> feedDetailLocs = feedDetails.stream().map(FeedDetail::getFeedDetailLoc).flatMap(Collection::stream).collect(Collectors.toList());
+
+        when(feedDetailLocRepository.saveAll(feedDetailLocs)).thenReturn(detailLocs);
+        feedDetailLocRepository.saveAll(feedDetailLocs);
+
+        List<FeedLocation> feedLocations = feedDetailLocs.stream()
+                .map(FeedDetailLoc::getFeedLocation)
+                .collect(Collectors.toList());
+
+        when(feedLocationRepository.saveAll(feedLocations)).thenReturn(locations);
+
+        //when
+        feedLocationRepository.saveAll(feedLocations);
+
+        //then
+        assertEquals(locations.size(), feedLocations.size());
+        assertEquals(locations.indexOf(0), feedLocations.indexOf(0));
+        assertEquals(locations.indexOf(1), feedLocations.indexOf(1));
+
+    }
+
+    @Test
+    @DisplayName("게시글 이미지 저장")
+    void createFeedDetailLocImg_normal() {
+        //given
+
+        List<FeedDetailLocImg> images = new ArrayList<>();
+
+        FeedDetailLocImg image_1 = FeedDetailLocImg.builder()
+                .fileName("tangerine.jpg")
+                .imgUrl("/images/jeju/tangerine.jpg")
+                .build();
+
+        FeedDetailLocImg image_2 = FeedDetailLocImg.builder()
+                .fileName("wind.jpg")
+                .imgUrl("/images/jeju/wind.jpg")
+                .build();
+
+        images.add(image_1);
+        images.add(image_2);
+
+        List<FeedDetailLoc> detailLocs = new ArrayList<>();
+
+        FeedDetailLoc feedDetailLoc_1 = FeedDetailLoc.builder()
+                .memo("감귤농장에서 귤 따기")
+                .feedDetailLocImg(images)
+                .build();
+
+        detailLocs.add(feedDetailLoc_1);
+
+        List<FeedDetail> details = new ArrayList<>();
+
+        FeedDetail feedDetail_1 = FeedDetail.builder()
+                .feedDetailLoc(detailLocs)
+                .day("1일차")
+                .build();
+
+        details.add(feedDetail_1);
+
+        FeedRequestDto.FeedRequestRegisterDto feedRequestRegisterDto = new FeedRequestDto.FeedRequestRegisterDto(
+                "제주도 여행기",
+                LocalDateTime.of(2020, 1, 23, 1, 00),
+                LocalDateTime.of(2020, 1, 30, 1, 00),
+                details);
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .title(feedRequestRegisterDto.getTitle())
+                .travelStart(feedRequestRegisterDto.getTravelStart())
+                .travelEnd(feedRequestRegisterDto.getTravelEnd())
+                .build();
+
+        when(feedRepository.save(any(Feed.class))).thenReturn(feed);
+        Feed saveFeed = feedRepository.save(feed);
+
+        feedRequestRegisterDto.getFeedDetail().stream().forEach(x -> x.setFeed(saveFeed));
+        when(feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail())).thenReturn(details);
+        feedDetailRepository.saveAll(feedRequestRegisterDto.getFeedDetail());
+
+        feedRequestRegisterDto.getFeedDetail().stream()
+                .forEach(x -> x.getFeedDetailLoc().forEach(y -> y.setFeedDetail(x)));
+        List<FeedDetailLoc> feedDetailLocs = details.stream().map(FeedDetail::getFeedDetailLoc).flatMap(Collection::stream).collect(Collectors.toList());
+
+        when(feedDetailLocRepository.saveAll(feedDetailLocs)).thenReturn(detailLocs);
+        feedDetailLocRepository.saveAll(feedDetailLocs);
+
+        feedRequestRegisterDto.getFeedDetail().stream().
+                forEach(x -> x.getFeedDetailLoc().forEach(y -> y.getFeedDetailLocImg().forEach(z -> z.setFeedDetailLoc(y))));
+
+        List<FeedDetailLocImg> feedDetailLocImgs = feedDetailLocs.stream()
+                .map(FeedDetailLoc::getFeedDetailLocImg)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        when(feedDetailLocImgRepository.saveAll(feedDetailLocImgs)).thenReturn(images);
+
+        //when
+        feedDetailLocImgRepository.saveAll(feedDetailLocImgs);
+
+        //then
+        assertEquals(images.size(), feedDetailLocImgs.size());
+        assertEquals(images.indexOf(0), feedDetailLocImgs.indexOf(0));
+        assertEquals(images.indexOf(1), feedDetailLocImgs.indexOf(1));
+    }
+
+    @Test
+    @DisplayName("수정 - 정상케이스")
+    void modify_normal() {
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/java/com/example/trip/service/impl/LikeServiceImplTest.java
+++ b/src/test/java/com/example/trip/service/impl/LikeServiceImplTest.java
@@ -1,0 +1,104 @@
+package com.example.trip.service.impl;
+
+import com.example.trip.advice.exception.AlreadyLikeException;
+import com.example.trip.advice.exception.FeedDetailLocNotFoundException;
+import com.example.trip.domain.*;
+import com.example.trip.dto.request.FeedRequestDto;
+import com.example.trip.dto.response.LikesResponseDto;
+import com.example.trip.repository.FeedDetailLocRepository;
+import com.example.trip.repository.LikeRepository;
+import com.example.trip.repository.UserRepository;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.trip.domain.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceImplTest {
+
+    @Mock
+    FeedDetailLocRepository feedDetailLocRepository;
+
+    @Mock
+    LikeRepository likeRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    FeedDetailLoc feedDetailLoc;
+
+    User user;
+
+    @BeforeEach
+    void setup() {
+        user = User.builder()
+                .email("kim@naver.com")
+                .username("babo")
+                .password("1234")
+                .memberstatus(true)
+                .socialaccountId("KAKAO_1234")
+                .role(USER)
+                .image(Image.builder().build())
+                .build();
+
+
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        userRepository.save(user);
+
+        List<FeedDetailLoc> detailLocs = new ArrayList<>();
+
+        feedDetailLoc = FeedDetailLoc.builder()
+                .memo("감귤농장에서 귤 따기")
+                .build();
+
+        detailLocs.add(feedDetailLoc);
+
+        when(feedDetailLocRepository.saveAll(detailLocs)).thenReturn(detailLocs);
+        feedDetailLocRepository.saveAll(detailLocs);
+    }
+
+    @Test
+    @DisplayName("좋아요 - 정상 케이스")
+    void createLike_normal() {
+
+        // given
+        Likes like = Likes.builder()
+                .feedDetailLoc(feedDetailLoc)
+                .user(user)
+                .build();
+
+        // when
+        when(likeRepository.save(like)).thenReturn(like);
+        likeRepository.save(like);
+
+        // then
+        assertEquals("감귤농장에서 귤 따기", like.getFeedDetailLoc().getMemo());
+        assertEquals("babo", like.getUser().getUsername());
+        assertEquals("kim@naver.com", like.getUser().getEmail());
+        assertEquals(USER, like.getUser().getRole());
+        assertEquals("KAKAO_1234", like.getUser().getSocialaccountId());
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 정상 케이스")
+    void cancelLike_normal() {
+
+
+
+    }
+
+}


### PR DESCRIPTION
### ✉️ 제목
[FIX] 토큰 재발급 API 추가 및 시큐리티 로직 변경(Filter추가) + [TEST] 도메인, 서비스 단위 테스트 코드 작성
### ☁️ 내용
- Access Token 만료 시, 재발급 API 작성(/api/token)
- 토큰 만료 시 에러 메세지와 코드를 뱉어내는 JwtExceptionFilter 추가하고 JwtAuthenticationFilter 전에 실행되도록 SecurityConfig 수정
- 도메인 테스트 코드 작성(성공 케이스만)
- 서비스 단 Unit Test 코드 작성(성공 케이스만)
### ❗️ 특이사항
- 서비스단 Unit Test 코드 중 Feed 수정 부분은 추가 변경 사항이 있을 수 있어, 아직 미작성된 상태
---

closes #
