### PR TITLE
[FIX] userdetailsservice에서 loaduserbyusername 부분 캐싱적용

### DIFF
--- a/src/main/java/com/example/trip/config/CachingConfig.java
+++ b/src/main/java/com/example/trip/config/CachingConfig.java
@@ -15,7 +15,7 @@ public class CachingConfig {
     @Bean
     public CacheManager cacheManager() {
         SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
-        simpleCacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("allFeeds"),new ConcurrentMapCache("feedlist"), new ConcurrentMapCache("feed"), new ConcurrentMapCache("feeddetailloc")));
+        simpleCacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("allFeeds"), new ConcurrentMapCache("user")));
         return simpleCacheManager;
     }
 }

--- a/src/main/java/com/example/trip/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/trip/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.trip.config;
 import com.example.trip.jwt.JwtAuthenticationFilter;
 import com.example.trip.jwt.JwtExceptionFilter;
 import com.example.trip.jwt.JwtTokenProvider;
+import com.example.trip.jwt.exceptionhandler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -57,7 +58,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated() // 위 antMatchers 이외에는 모든 api 인증 필요
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint());
 
 
     }

--- a/src/main/java/com/example/trip/config/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/trip/config/security/UserDetailsServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.trip.config.security;
 
 import com.example.trip.domain.User;
 import com.example.trip.repository.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -14,6 +15,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     public UserDetailsServiceImpl(UserRepository userRepository) { this.userRepository = userRepository; }
 
+    @Cacheable(value = "user")
     public UserDetails loadUserByUsername(String socialaccountId) throws UsernameNotFoundException {
         User user = userRepository.findBySocialaccountId(socialaccountId).orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
         return new UserDetailsImpl(user);

--- a/src/main/java/com/example/trip/controller/UserController.java
+++ b/src/main/java/com/example/trip/controller/UserController.java
@@ -14,6 +14,7 @@ import com.example.trip.service.RedisService;
 import com.example.trip.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -98,7 +99,7 @@ public class UserController {
     // 로그아웃
     @GetMapping("/api/logout")
     public ResponseEntity<ResponseNoData> logout(HttpServletRequest request) {
-        redisService.delValues(request.getHeader("refreshToken"));
+        socialLoginService.logout(request.getHeader("refreshToken"));
         return new ResponseEntity<>(ResponseNoData.builder()
                 .result("success").msg("로그아웃 성공!").build(), HttpStatus.OK);
     }

--- a/src/main/java/com/example/trip/service/SocialLoginService.java
+++ b/src/main/java/com/example/trip/service/SocialLoginService.java
@@ -47,4 +47,6 @@ public interface SocialLoginService {
     TokenResponseDto reissueToken(TokenRequestDto requestDto);
 
     User getUser(String socialaccountId);
+
+    void logout(String refreshToken);
 }


### PR DESCRIPTION
### ✉️ 제목
[FIX] userdetailsservice에서 loaduserbyusername 부분 캐싱적용

### ☁️ 내용
- 로그인 후 첫번째로 loaduserbyusername을 불러올 때 캐싱 적용을 해서 그 이후에는 따로 유저 정보를 불러오는 query가 날라가지 않도록 수정함
- 로그아웃 및 회원탈퇴 시 해당 캐쉬는 clear 됨

### ❗️ 특이사항

---

closes #
